### PR TITLE
Change domain from kt.blog.ccmp.jp to ktaka.blog.ccmp.jp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 ## Project Overview
 
-This is a Zola-based blog containing technical articles in Markdown, organized by year. The blog is published at `kt.blog.ccmp.jp` via GitHub Pages. Zola (v0.22.1) is used as the static site generator.
+This is a Zola-based blog containing technical articles in Markdown, organized by year. The blog is published at `ktaka.blog.ccmp.jp` via GitHub Pages. Zola (v0.22.1) is used as the static site generator.
 
 ## Repository Structure
 

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-base_url = "https://kt.blog.ccmp.jp"
+base_url = "https://ktaka.blog.ccmp.jp"
 title = "ktaka's blog"
 default_language = "ja"
 compile_sass = false

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-kt.blog.ccmp.jp
+ktaka.blog.ccmp.jp


### PR DESCRIPTION
Update base_url, CNAME, and documentation to reflect domain migration.