### PR TITLE
Update FedCM article publish date and add Zenn/dev.to versions

### DIFF
--- a/content/2026/Oauth2PasskeyFedCM/index.md
+++ b/content/2026/Oauth2PasskeyFedCM/index.md
@@ -1,6 +1,6 @@
 +++
 title = "Rust 認証ライブラリ oauth2-passkey で FedCM ログイン機能を実装した"
-date = 2026-03-13
+date = 2026-03-14
 description = "FedCM ログイン機能の実装記録。ブラウザ標準 API の利用、JWT 検証の再利用、セキュリティのトレードオフ。"
 path = "2026/Oauth2PasskeyFedCM"
 +++

--- a/content/2026/Oauth2PasskeyFedCMEn/index.md
+++ b/content/2026/Oauth2PasskeyFedCMEn/index.md
@@ -1,6 +1,6 @@
 +++
 title = "Implementing FedCM Login in the oauth2-passkey Rust Library"
-date = 2026-03-13
+date = 2026-03-14
 description = "An implementation record of FedCM login: using the browser standard API, reusing JWT validation, and security trade-offs."
 path = "en/2026/Oauth2PasskeyFedCM"
 +++

--- a/docs/Oauth2PasskeyFedCM-zenn/zenn-oauth2-passkey-fedcm.md
+++ b/docs/Oauth2PasskeyFedCM-zenn/zenn-oauth2-passkey-fedcm.md
@@ -1,0 +1,164 @@
+> この記事は [ktaka.blog.ccmp.jp の記事](https://ktaka.blog.ccmp.jp/2026/Oauth2PasskeyFedCM) のクロスポストです。
+
+FedCM (Federated Credential Management) は、ブラウザがネイティブUIで提供するW3C標準の認証APIである。ポップアップやリダイレクトを使わず、ブラウザ自身がアカウント選択画面を表示し、IDプロバイダーと直接通信する。
+
+[oauth2-passkey](https://github.com/ktaka-ccmp/oauth2-passkey) のRustライブラリに、このFedCMログインを実装した記録を紹介する。
+
+---
+
+## FedCMとは
+
+従来のOAuth2 Authorization Code Flowでは、RP（あなたのアプリ）がGoogleのページにリダイレクトし、認証後にコールバックURLに戻ってくる。FedCMでは、`navigator.credentials.get()`を呼ぶだけで、ブラウザが直接Googleと通信してJWT IDトークンを返す。
+
+```text
+従来のOAuth2 Authorization Code Flow:
+  ボタンクリック -> ポップアップ -> Googleの認証画面
+    -> リダイレクト（認可コード付き）
+    -> バックエンドがGoogleとコード交換（サーバー間通信）
+    -> IDトークン取得 -> 検証 -> セッション確立
+
+FedCM:
+  ボタンクリック -> navigator.credentials.get()
+    -> ブラウザがネイティブUIでアカウント選択画面を表示
+    -> ブラウザがGoogleからJWT IDトークンを直接取得
+    -> JSがトークンをバックエンドにPOST -> 検証 -> セッション確立
+```
+
+FedCMではブラウザが仲介役になるので、RPからロードしたJavaScriptはアカウントの一覧を見ることもできない。ブラウザがGoogleのセッションCookieを使って、ネイティブUIにアカウント情報を表示し、ユーザーが選択した結果だけがJavaScriptに返される。
+
+## UI比較
+
+![FedCMのアカウント選択画面](画像URL: fedcm-account-chooser.png)
+*FedCMのアカウント選択画面（ブラウザがネイティブUIを表示）*
+
+![従来のOAuth2ポップアップ](画像URL: oauth2-popup.png)
+*従来のOAuth2 Authorization Code Flow（ポップアップウィンドウでGoogleの認証画面を表示）*
+
+## フロントエンド実装
+
+FedCMのフロントエンド実装は3ステップである。
+
+### 1. Nonceの取得
+
+```javascript
+const nonceResponse = await fetch('/api/fedcm/nonce');
+const nonceData = await nonceResponse.json();
+// { nonce: "ランダム文字列", nonce_id: "キャッシュキー" }
+```
+
+### 2. navigator.credentials.get() の呼び出し
+
+```javascript
+const credential = await navigator.credentials.get({
+    identity: {
+        providers: [{
+            configURL: 'https://accounts.google.com/gsi/fedcm.json',
+            clientId: OAUTH2_CLIENT_ID,
+            params: {
+                nonce: nonceData.nonce,
+                response_type: 'id_token',
+                scope: 'email profile openid',
+                ss_domain: window.location.origin,
+            },
+        }],
+        mode: 'active',
+        context: 'signin',
+    },
+    mediation: 'required',  // 自動再認証を防ぎ、常にユーザー操作を要求
+});
+```
+
+`mode: 'active'`は`identity`オブジェクトの直下に配置することが重要である。`providers`内に入れるとChromeが無視してpassive modeで動作し、ユーザーがダイアログを閉じるとクールダウンが発生してしまう。
+
+### 3. バックエンドへのトークン送信
+
+```javascript
+const response = await fetch('/api/fedcm/callback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+        token: credential.token,
+        nonce_id: nonceData.nonce_id
+    })
+});
+
+if (response.ok) {
+    // ログイン成功、Set-Cookieヘッダーでセッションクッキーが設定される
+    window.location.reload();
+}
+```
+
+## バックエンド実装
+
+バックエンドの処理は5ステップである。
+
+### 1. JWT検証（署名、iss/aud/exp、nonce）
+
+```rust
+fn validate_fedcm_token(token: String, nonce_id: String) -> IdInfo {
+    // JWT署名検証、aud/iss/exp検証
+    let idinfo = verify_idtoken(token, CLIENT_ID);
+
+    // Nonce検証（単一使用を保証）
+    verify_and_consume_nonce(nonce_id, idinfo.nonce);
+
+    idinfo
+}
+```
+
+JWT検証では以下を確認する:
+- **署名検証**: GoogleのJWKS（公開鍵セット）を取得し、JWTヘッダーの`kid`で鍵を選択して署名検証
+- **クレーム検証**: `iss`（発行者）、`aud`（Client ID）、`exp`（有効期限）が正しいことを確認
+- **Nonce検証**: IDトークン内の`nonce`クレームが事前生成した値と一致することを確認し、検証後にキャッシュから削除して再利用を防ぐ
+
+GoogleのFedCMエンドポイントが返すJWTは、Authorization Code Flowで取得するIDトークンと同じフォーマットである。つまり、既存のOAuth2認証のJWT検証コードをそのまま再利用できる。
+
+### 2-5. ユーザー情報抽出、アカウント検索/作成、セッション作成、Set-Cookieヘッダー返却
+
+これらの処理は従来のOAuth2フローと共通である。詳細は[完全版記事](https://ktaka.blog.ccmp.jp/2026/Oauth2PasskeyFedCM)を参照。
+
+## セキュリティ上の考慮点
+
+FedCMはUX改善をもたらすが、セキュリティモデルが従来のOAuth2/OIDCフローと異なる。
+
+| 項目 | Authorization Code Flow + PKCE | FedCM |
+|------|------|------|
+| IDトークン取得 | サーバーが認可コードと交換 | ブラウザが直接取得 |
+| JavaScriptがアクセスできる情報 | 認可コード（単体では無価値） | JWT IDトークン（認証に使える） |
+| XSS攻撃のリスク | 認可コードだけでは認証できない | 有効期限内であれば認証に使える |
+
+筆者の理解では、OAuth2 + PKCEの方がXSS攻撃への耐性が高い。なお、GoogleのOne Tap（GIS SDK）も同じモデルを採用している。
+
+## ブラウザサポート
+
+| ブラウザ | サポート状況 |
+|---------|-------------|
+| Chrome 108+ | サポート |
+| Edge 108+ | サポート |
+| Safari | 未サポート（ポップアップにフォールバック） |
+| Firefox | 未サポート（ポップアップにフォールバック） |
+
+## まとめ
+
+FedCM実装を通じて明らかになったこと:
+
+- FedCMのフロントエンドはnonce取得 → `navigator.credentials.get()` → バックエンドへPOSTの3ステップ
+- バックエンドはJWT検証 → ユーザー情報抽出 → アカウント検索/作成 → セッション作成 → Set-Cookieの流れ。既存のJWT検証コードをそのまま再利用可能
+- セキュリティモデルはAuthorization Code Flowと異なり、OAuth2 + PKCEの方がXSS攻撃への耐性が高い。FedCMはUX改善を優先したトレードオフ
+- `navigator.credentials.get()`のパラメーターにはGoogle固有の要件があり、`mode: 'active'`の配置など正しい記法が重要
+
+実装例は[oauth2-passkey](https://github.com/ktaka-ccmp/oauth2-passkey)を参照。[デモサイト](https://passkey-demo.ccmp.jp)で実際の動作を試せる。
+
+## リンク
+
+- **完全版記事**: [ktaka.blog.ccmp.jp/2026/Oauth2PasskeyFedCM](https://ktaka.blog.ccmp.jp/2026/Oauth2PasskeyFedCM)
+- **ライブデモ**: [passkey-demo.ccmp.jp](https://passkey-demo.ccmp.jp)
+- **GitHub**: [ktaka-ccmp/oauth2-passkey](https://github.com/ktaka-ccmp/oauth2-passkey)
+- **ドキュメント**: [ktaka-ccmp.github.io/oauth2-passkey](https://ktaka-ccmp.github.io/oauth2-passkey/)
+
+## 参考
+
+- [FedCM W3C Spec](https://www.w3.org/TR/fedcm/)
+- [MDN: FedCM API](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API)
+- [Chrome: RP Implementation Guide](https://developer.chrome.com/docs/identity/fedcm/implement/relying-party)
+- [Google: FedCM Migration Guide](https://developers.google.com/identity/gsi/web/guides/fedcm-migration)

--- a/docs/Oauth2PasskeyFedCMEn-devto/dev-to-oauth2-passkey-fedcm.md
+++ b/docs/Oauth2PasskeyFedCMEn-devto/dev-to-oauth2-passkey-fedcm.md
@@ -1,0 +1,170 @@
+---
+title: "Implementing FedCM Login: Browser-Native Authentication Without Popups"
+published: true
+description: "Implementation record of FedCM login in the oauth2-passkey Rust library: using the browser standard API, reusing JWT validation, and security trade-offs."
+tags: rust, webauthn, authentication, fedcm
+canonical_url: https://ktaka.blog.ccmp.jp/en/2026/Oauth2PasskeyFedCM
+---
+
+FedCM (Federated Credential Management) is a W3C standard API that enables federated authentication through browser-native UI. Instead of popup windows or redirects, the browser itself displays an account chooser and communicates directly with the identity provider.
+
+This article explains how I implemented FedCM in the [oauth2-passkey](https://github.com/ktaka-ccmp/oauth2-passkey) Rust library, how it differs from the traditional OAuth2 flow, and the security trade-offs involved.
+
+---
+
+## What is FedCM?
+
+In the traditional OAuth2 Authorization Code Flow, the RP (your app) redirects to Google's page, and after authentication, returns to a callback URL. With FedCM, you simply call `navigator.credentials.get()`, the browser communicates directly with Google, and returns a JWT ID token.
+
+```text
+Traditional OAuth2 Authorization Code Flow:
+  Button click -> Popup -> Google auth page
+    -> Redirect (with authorization code)
+    -> Backend exchanges code with Google (server-to-server)
+    -> Obtain ID token -> Validate -> Establish session
+
+FedCM:
+  Button click -> navigator.credentials.get()
+    -> Browser displays native UI account chooser
+    -> Browser obtains JWT ID token directly from Google
+    -> JS posts token to backend -> Validate -> Establish session
+```
+
+With FedCM, the browser acts as an intermediary, so JavaScript loaded from the RP cannot see the list of accounts. The browser uses Google's session cookies to display account information in the native UI, and only returns the user's selected result to JavaScript.
+
+## UI Comparison
+
+![Image description](IMAGE_URL: fedcm-account-chooser.png)
+*FedCM account chooser (browser displays native UI)*
+
+![Image description](IMAGE_URL: oauth2-popup.png)
+*Traditional OAuth2 Authorization Code Flow (displays Google auth page in popup window)*
+
+## Frontend Implementation
+
+The FedCM frontend implementation consists of three steps.
+
+### 1. Obtaining a Nonce
+
+```javascript
+const nonceResponse = await fetch('/api/fedcm/nonce');
+const nonceData = await nonceResponse.json();
+// { nonce: "random string", nonce_id: "cache key" }
+```
+
+### 2. Calling navigator.credentials.get()
+
+```javascript
+const credential = await navigator.credentials.get({
+    identity: {
+        providers: [{
+            configURL: 'https://accounts.google.com/gsi/fedcm.json',
+            clientId: OAUTH2_CLIENT_ID,
+            params: {
+                nonce: nonceData.nonce,
+                response_type: 'id_token',
+                scope: 'email profile openid',
+                ss_domain: window.location.origin,
+            },
+        }],
+        mode: 'active',
+        context: 'signin',
+    },
+    mediation: 'required',  // Prevent auto re-authn, always require user interaction
+});
+```
+
+It's important that `mode: 'active'` is placed directly under the `identity` object. If placed inside the provider object, Chrome ignores it and operates in passive mode, causing a cooldown when the user closes the dialog.
+
+### 3. Sending the Token to the Backend
+
+```javascript
+const response = await fetch('/api/fedcm/callback', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+        token: credential.token,
+        nonce_id: nonceData.nonce_id
+    })
+});
+
+if (response.ok) {
+    // Login successful, session cookie set via Set-Cookie header
+    window.location.reload();
+}
+```
+
+## Backend Implementation
+
+The backend processing consists of five steps.
+
+### 1. JWT Validation (signature, iss/aud/exp, nonce)
+
+```rust
+fn validate_fedcm_token(token: String, nonce_id: String) -> IdInfo {
+    // JWT signature validation, aud/iss/exp validation
+    let idinfo = verify_idtoken(token, CLIENT_ID);
+
+    // Nonce validation (ensures single use)
+    verify_and_consume_nonce(nonce_id, idinfo.nonce);
+
+    idinfo
+}
+```
+
+JWT validation verifies the following:
+- **Signature verification**: Fetch Google's JWKS (public key set), select the key using the `kid` in the JWT header, and verify the signature
+- **Claim validation**: Verify that `iss` (issuer), `aud` (Client ID), and `exp` (expiration) are correct
+- **Nonce validation**: Verify that the `nonce` claim in the ID token matches the pre-generated value, then delete it from the cache after verification to prevent reuse
+
+The JWT returned by Google's FedCM endpoint is in the same format as the ID token obtained through the Authorization Code Flow. This means existing OAuth2 authentication JWT validation code can be reused as-is.
+
+### 2-5. User Info Extraction, Account Lookup/Creation, Session Creation, Set-Cookie Response
+
+These steps are common with the traditional OAuth2 flow. See the [full article](https://ktaka.blog.ccmp.jp/en/2026/Oauth2PasskeyFedCM) for details.
+
+## Security Considerations
+
+FedCM brings UX improvements, but its security model differs from the traditional OAuth2/OIDC flow.
+
+| Aspect | Authorization Code Flow + PKCE | FedCM |
+|------|------|------|
+| ID token acquisition | Server exchanges authorization code | Browser obtains directly |
+| JavaScript-accessible information | Authorization code (worthless) | JWT ID token (usable for authentication) |
+| XSS attack risk | Authorization code alone cannot authenticate | Usable for authentication within validity period |
+
+In my understanding, OAuth2 + PKCE has higher resistance to XSS attacks. Note that Google's One Tap (GIS SDK) also adopts the same model as FedCM.
+
+## Browser Support
+
+| Browser | Support |
+|---------|---------|
+| Chrome 108+ | Supported |
+| Edge 108+ | Supported |
+| Safari | Not supported (falls back to popup) |
+| Firefox | Not supported (falls back to popup) |
+
+## Summary
+
+What became clear through implementing FedCM:
+
+- The FedCM frontend is a 3-step process: nonce acquisition → `navigator.credentials.get()` → POST to backend
+- The backend follows: JWT validation → user info extraction → user search/creation → session creation → Set-Cookie. Existing JWT validation code can be reused as-is
+- The security model differs from the Authorization Code Flow; OAuth2 + PKCE has higher resistance to XSS attacks. FedCM is a trade-off that prioritizes UX improvement
+- Parameters for `navigator.credentials.get()` have Google-specific requirements, and correct notation such as `mode: 'active'` placement is crucial
+
+See [oauth2-passkey](https://github.com/ktaka-ccmp/oauth2-passkey) for implementation examples. Try the actual behavior at the [demo site](https://passkey-demo.ccmp.jp).
+
+## Links
+
+- **Full article**: [ktaka.blog.ccmp.jp/en/2026/Oauth2PasskeyFedCM](https://ktaka.blog.ccmp.jp/en/2026/Oauth2PasskeyFedCM)
+- **Live demo**: [passkey-demo.ccmp.jp](https://passkey-demo.ccmp.jp)
+- **GitHub**: [ktaka-ccmp/oauth2-passkey](https://github.com/ktaka-ccmp/oauth2-passkey)
+- **Documentation**: [ktaka-ccmp.github.io/oauth2-passkey](https://ktaka-ccmp.github.io/oauth2-passkey/)
+
+## References
+
+- [FedCM W3C Spec](https://www.w3.org/TR/fedcm/)
+- [MDN: FedCM API](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API)
+- [Chrome: RP Implementation Guide](https://developer.chrome.com/docs/identity/fedcm/implement/relying-party)
+- [Google: FedCM Migration Guide](https://developers.google.com/identity/gsi/web/guides/fedcm-migration)


### PR DESCRIPTION
- Update publish date from 2026-03-13 to 2026-03-14
- Add Zenn cross-post (Japanese) in docs/Oauth2PasskeyFedCM-zenn/
- Add dev.to cross-post (English) in docs/Oauth2PasskeyFedCMEn-devto/